### PR TITLE
Japanese pretty (very cute) translation file import function

### DIFF
--- a/etc/Translation/LameXP_JA.ts
+++ b/etc/Translation/LameXP_JA.ts
@@ -1,0 +1,3583 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja_JP" sourcelanguage="en">
+<context>
+    <name>AboutDialog</name>
+    <message>
+        <location filename="../../gui/AboutDialog.ui" line="20"/>
+        <source>About LameXP</source>
+        <translation>LameXP について</translation>
+    </message>
+    <message>
+        <location filename="../../gui/AboutDialog.ui" line="40"/>
+        <source>Information</source>
+        <translation>情報</translation>
+    </message>
+    <message>
+        <location filename="../../gui/AboutDialog.ui" line="138"/>
+        <source>Contributors</source>
+        <translation>貢献者</translation>
+    </message>
+    <message>
+        <location filename="../../gui/AboutDialog.ui" line="236"/>
+        <source>3rd Party S/W</source>
+        <translation>第三者のプログラム</translation>
+    </message>
+    <message>
+        <location filename="../../gui/AboutDialog.ui" line="334"/>
+        <source>License</source>
+        <translation>ライセンス</translation>
+    </message>
+    <message>
+        <location filename="../../gui/AboutDialog.ui" line="439"/>
+        <source>Show License Text</source>
+        <translation>ライセンス条項の表示</translation>
+    </message>
+    <message>
+        <location filename="../../gui/AboutDialog.ui" line="478"/>
+        <source>Accept License</source>
+        <translation>ライセンス条項に同意</translation>
+    </message>
+    <message>
+        <location filename="../../gui/AboutDialog.ui" line="498"/>
+        <source>Decline License</source>
+        <translation>ライセンス条項を拒否</translation>
+    </message>
+    <message>
+        <location filename="../../gui/AboutDialog.ui" line="518"/>
+        <source>About Qt...</source>
+        <translation>Qt について ...</translation>
+    </message>
+    <message>
+        <location filename="../../gui/AboutDialog.ui" line="535"/>
+        <source>Discard</source>
+        <translation>閉じる</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="565"/>
+        <source>LameXP - Audio Encoder Front-end</source>
+        <translation>LameXP - オーディオエンコードフロントエンド</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="569"/>
+        <source>Please visit %1 for news and updates!</source>
+        <translation>新着情報と更新のためには %1 にアクセスしてください！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="581"/>
+        <location filename="../../src/Dialog_About.cpp" line="593"/>
+        <source>Note: This demo (pre-release) version of LameXP will expire at %1. Still %2 days left.</source>
+        <translation>注: LameXP のデモ版 (正式公開前) です。有効期限は %1.まで、残り %2 日です。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="613"/>
+        <source>Note: LameXP is free software. Do &lt;b&gt;not&lt;/b&gt; pay money to obtain or use LameXP! If some third-party website tries to make you pay for downloading LameXP, you should &lt;b&gt;not&lt;/b&gt; respond to the offer !!!</source>
+        <translation>注 : LameXP は無料のソフトウェアです。 LameXP の入手や利用にお金を&lt;b&gt;払わないで&lt;/b&gt;！どこかのサイトで LameXP をダウンロードするのに支払いを求められても、これに&lt;b&gt;応じないで&lt;/b&gt;！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="627"/>
+        <source>The following people have contributed to LameXP:</source>
+        <translation>LameXP の開発に貢献した人たちだよ :</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="630"/>
+        <source>Programmers:</source>
+        <translation>プログラマー :</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="633"/>
+        <source>Project Leader</source>
+        <translation>プロジェクトリーダー</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="637"/>
+        <source>Translators:</source>
+        <translation>翻訳者 :</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="647"/>
+        <source>Special thanks to:</source>
+        <translation>心から感謝します :</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="657"/>
+        <source>Official Mirrors:</source>
+        <translation>公式ミラーサイト :</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="667"/>
+        <source>If you are willing to contribute a LameXP translation, feel free to contact us!</source>
+        <translation>LameXP の翻訳に貢献したいなら、お気軽に連絡ください！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="678"/>
+        <source>The following third-party software is used in LameXP:</source>
+        <translation>LameXP で使われているサードパーティー製ソフトウェア :</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="683"/>
+        <source>LAME - OpenSource mp3 Encoder</source>
+        <translation>LAME - オープンソースの mp3 エンコーダー</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="685"/>
+        <location filename="../../src/Dialog_About.cpp" line="707"/>
+        <location filename="../../src/Dialog_About.cpp" line="728"/>
+        <location filename="../../src/Dialog_About.cpp" line="749"/>
+        <location filename="../../src/Dialog_About.cpp" line="763"/>
+        <location filename="../../src/Dialog_About.cpp" line="777"/>
+        <location filename="../../src/Dialog_About.cpp" line="791"/>
+        <location filename="../../src/Dialog_About.cpp" line="826"/>
+        <location filename="../../src/Dialog_About.cpp" line="833"/>
+        <location filename="../../src/Dialog_About.cpp" line="840"/>
+        <location filename="../../src/Dialog_About.cpp" line="854"/>
+        <source>Released under the terms of the GNU Lesser General Public License.</source>
+        <translation>GNU Lesser General Public License で公開されています。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="690"/>
+        <source>OggEnc - Vorbis Encoder</source>
+        <translation>OggEnc - Vorbis エンコーダー</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="692"/>
+        <source>Completely open and patent-free audio encoding technology.</source>
+        <translation>完全にオープンで特許のないフリーな音声エンコード技術。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="697"/>
+        <source>Nero AAC Reference MPEG-4 Encoder</source>
+        <translation>Nero AAC Reference MPEG-4 エンコーダー</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="699"/>
+        <source>Freeware state-of-the-art HE-AAC encoder with 2-Pass support.</source>
+        <translation>2 パスに対応するフリーウェア最先端の HE-AAC エンコーダー。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="701"/>
+        <source>Available from vendor web-site as free download:</source>
+        <translation>開発者のサイトから自由にダウンロードできます :</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="705"/>
+        <source>Aften - A/52 audio encoder</source>
+        <translation>Aften - A/52 音声エンコーダー</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="712"/>
+        <source>FLAC - Free Lossless Audio Codec</source>
+        <translation>FLAC - Free Lossless Audio Codec</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="714"/>
+        <source>Open and patent-free lossless audio compression technology.</source>
+        <translation>オープンで特許のないロスレス音声圧縮技術。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="719"/>
+        <source>Opus Audio Codec</source>
+        <translation>Opus 音声コーデック</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="721"/>
+        <source>Totally open, royalty-free, highly versatile audio codec.</source>
+        <translation>完全にオープンで、使用料のない万能音声コーデック。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="726"/>
+        <source>mpg123 - Fast Console MPEG Audio Player/Decoder</source>
+        <translation>mpg123 - 高速なコンソール型 MPEG オーディオプレーヤー / デコーダー</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="733"/>
+        <source>FAAD - OpenSource MPEG-4 and MPEG-2 AAC Decoder</source>
+        <translation>FAAD - オープンソースの MPEG-4 と MPEG-2 AAC デコーダー</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="735"/>
+        <source>Released under the terms of the GNU General Public License.</source>
+        <translation>GNU General Public License.で公開されています。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="740"/>
+        <source>OggDec - Vorbis Decoder</source>
+        <translation>OggDec - Vorbis デコーダー</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="742"/>
+        <source>Command line Ogg Vorbis decoder created by John33.</source>
+        <translation>John33 が作ったコマンドライン型 Ogg Vorbis デコーダー。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="747"/>
+        <source>Valdec from AC3Filter Tools - AC3/DTS Decoder</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="754"/>
+        <source>WavPack - Hybrid Lossless Compression</source>
+        <translation>WavPack - ハイブリッドなロスレス圧縮</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="756"/>
+        <source>Completely open audio compression format.</source>
+        <translation>完全にオープンな音声圧縮形式。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="761"/>
+        <source>Musepack - Living Audio Compression</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="768"/>
+        <source>Monkey&apos;s Audio - Lossless Audio Compressor</source>
+        <translation>Monkey&apos;s Audio - ロスレス音声圧縮</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="770"/>
+        <source>Freely available source code, simple SDK and non-restrictive licensing.</source>
+        <translation>自由に使えるソースコード、シンプルな SDK 、制限のないライセンス。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="775"/>
+        <source>Shorten - Lossless Audio Compressor</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="782"/>
+        <source>Speex - Free Codec For Free Speech</source>
+        <translation>Speex - 言論の自由のための自由なコーデック</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="784"/>
+        <source>Open Source patent-free audio format designed for speech.</source>
+        <translation>言論用に設計されたオープンソースで特許のない音声フォーマット。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="789"/>
+        <source>The True Audio - Lossless Audio Codec</source>
+        <translation>The True Audio - ロスレス音声コーデック</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="796"/>
+        <source>refalac - Win32 command line ALAC encoder/decoder</source>
+        <translation>refalac - Win32 コマンドライン型 ALAC エンコーダー / デコーダー</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="798"/>
+        <source>The ALAC reference implementation by Apple is available under the Apache license.</source>
+        <translation>Apple 製の ALAC を参照して実装する際は Apache ライセンスで利用できます。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="803"/>
+        <source>wma2wav - Dump WMA files to Wave Audio</source>
+        <translation>wma2wav - WMA ファイルを Wave オーディオにダンプする</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="805"/>
+        <source>Copyright (c) 2011 LoRd_MuldeR &amp;lt;mulder2@gmx.de&amp;gt;. Some rights reserved.</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="812"/>
+        <source>By Jory Stone &amp;lt;jcsston@toughguy.net&amp;gt; and LoRd_MuldeR &amp;lt;mulder2@gmx.de&amp;gt;.</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="845"/>
+        <source>cURL - Curl URL Request Library</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="847"/>
+        <source>By Daniel Stenberg, released under the terms of the MIT/X Derivate License.</source>
+        <translation>Daniel Stenberg による MIT/X Derivate License にて公開されています。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="810"/>
+        <source>avs2wav - Avisynth to Wave Audio converter</source>
+        <translation>avs2wav - Avisynth を Wave オーディオに変換</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="817"/>
+        <source>dcaenc</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="819"/>
+        <source>Copyright (c) 2008-2011 Alexander E. Patrakov. Distributed under the LGPL.</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="824"/>
+        <source>MediaInfo - Media File Analysis Tool</source>
+        <translation>MediaInfo - メディアファイル分析ツール</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="831"/>
+        <source>SoX - Sound eXchange</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="838"/>
+        <source>GnuPG - The GNU Privacy Guard</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="852"/>
+        <source>UPX - The Ultimate Packer for eXecutables</source>
+        <translation>UPX - 実行ファイルの究極圧縮機</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="859"/>
+        <source>Silk Icons - Over 700 icons in PNG format</source>
+        <translation>Silk Icons - 700 を超える PNG 形式のアイコン</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="861"/>
+        <source>By Mark James, released under the Creative Commons &apos;BY&apos; License.</source>
+        <translation>Mark James により、 Creative Commons BY License で公開されています。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="866"/>
+        <source>Angry Chicken and Ghost Scream sound</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="868"/>
+        <source>By Alexander, released under the Creative Commons &apos;BY&apos; License.</source>
+        <translation>Alexander により Creative Commons BY License で公開されています。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="873"/>
+        <source>The copyright of LameXP as a whole belongs to LoRd_MuldeR. The copyright of third-party software used in LameXP belongs to the individual authors.</source>
+        <translation>LameXP の著作権は LoRd_MuldeR に帰属します。LameXP で利用されているサードパーティー製ソフトウェアの著作権はそれぞれの開発者に帰属します。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_About.cpp" line="928"/>
+        <source>n/a</source>
+        <translation>なし</translation>
+    </message>
+</context>
+<context>
+    <name>AudioFileModel</name>
+    <message>
+        <location filename="../../src/Model_AudioFile.cpp" line="308"/>
+        <location filename="../../src/Model_AudioFile.cpp" line="364"/>
+        <source>Profile</source>
+        <translation>プロファイル</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_AudioFile.cpp" line="325"/>
+        <source>Channels</source>
+        <translation>チャンネル</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_AudioFile.cpp" line="330"/>
+        <source>Samplerate</source>
+        <translation>サンプルレート</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_AudioFile.cpp" line="337"/>
+        <location filename="../../src/Model_AudioFile.cpp" line="341"/>
+        <source>Bitdepth</source>
+        <translation>ビット深度</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_AudioFile.cpp" line="359"/>
+        <source>Type</source>
+        <translation>種類</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_AudioFile.cpp" line="368"/>
+        <source>Version</source>
+        <translation>バージョン</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_AudioFile.cpp" line="375"/>
+        <location filename="../../src/Model_AudioFile.cpp" line="378"/>
+        <location filename="../../src/Model_AudioFile.cpp" line="381"/>
+        <source>Bitrate</source>
+        <translation>ビットレート</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_AudioFile.cpp" line="375"/>
+        <source>Constant</source>
+        <translation>固定</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_AudioFile.cpp" line="378"/>
+        <source>Variable</source>
+        <translation>可変</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_AudioFile.cpp" line="387"/>
+        <source>Encoder</source>
+        <translation>エンコーダー</translation>
+    </message>
+</context>
+<context>
+    <name>CueImportDialog</name>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="94"/>
+        <source>Import Cue Sheet</source>
+        <translation>キューシートのインポート</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="94"/>
+        <source>The following Cue Sheet will be split and imported into LameXP.</source>
+        <translation>以下のキューシートがLameXPへとインポートされ、分割を行います。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="120"/>
+        <source>Loading Cue Sheet file, please be patient...</source>
+        <translation>キューシートファイルの読み込み中、お待ちください...</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="125"/>
+        <location filename="../../src/Dialog_CueImport.cpp" line="226"/>
+        <source>Failed to load the Cue Sheet file:</source>
+        <translation>キューシートファイルの読み込みに失敗しました:</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="125"/>
+        <source>The specified file could not be found!</source>
+        <translation>指定されたファイルは見つかりませんでした！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="126"/>
+        <location filename="../../src/Dialog_CueImport.cpp" line="227"/>
+        <location filename="../../src/Dialog_CueImport.cpp" line="369"/>
+        <location filename="../../src/Dialog_CueImport.cpp" line="442"/>
+        <location filename="../../src/Dialog_CueImport.cpp" line="446"/>
+        <source>Cue Sheet Error</source>
+        <translation>キューシートのエラー</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="154"/>
+        <source>(System Default)</source>
+        <translation>(システムの規定)</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="161"/>
+        <source>Select ANSI Codepage for Cue Sheet file:</source>
+        <translation>キューシートのANSIコードページ(文字コード)を選択:</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="162"/>
+        <source>OK</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="163"/>
+        <source>Cancel</source>
+        <translation>キャンセル</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="195"/>
+        <source>New Folder</source>
+        <translation type="unfinished">新規フォルダ</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="208"/>
+        <source>An unknown error has occured!</source>
+        <translation>不明なエラーが発生しました！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="213"/>
+        <source>The file could not be opened for reading. Make sure you have the required rights!</source>
+        <translation>ファイルを読み込みのために開けませんでした。読み取り権限があるか確認してください！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="216"/>
+        <source>The provided file does not look like a valid Cue Sheet disc image file!</source>
+        <translation>指定されたファイルは正しいキューシートディスクイメージのファイルではありません！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="219"/>
+        <source>Could not find any supported audio track in the Cue Sheet image!</source>
+        <translation>キューシートのイメージに対応する音声トラックが見つかりません！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="219"/>
+        <source>Note that LameXP can not handle &quot;binary&quot; Cue Sheet images.</source>
+        <translation>LameXP はバイナリ形式のキューシートのイメージは処理できません。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="222"/>
+        <source>The selected Cue Sheet file contains inconsistent information. Take care!</source>
+        <translation>選択したキューシートには一貫しない情報が含まれています。注意してください！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="244"/>
+        <source>Unknown Artist</source>
+        <translation>不明なアーティスト</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="245"/>
+        <source>Unknown Album</source>
+        <translation>不明なアルバム</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="266"/>
+        <location filename="../../src/Dialog_CueImport.cpp" line="270"/>
+        <source>Choose Output Directory</source>
+        <translation>出力フォルダの選択</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="296"/>
+        <location filename="../../src/Dialog_CueImport.cpp" line="303"/>
+        <source>LameXP</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="296"/>
+        <source>Error: The selected output directory could not be created!</source>
+        <translation>エラー: 選択した出力フォルダが作成できませんでした！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="303"/>
+        <source>Error: The selected output directory is not writable!</source>
+        <translation>エラー: 選択した出力フォルダには書き込みできません！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="317"/>
+        <source>Low Diskspace Warning</source>
+        <translation type="unfinished">空き容量の低下の警告</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="317"/>
+        <source>There are less than %1 GB of free diskspace available in the selected output directory.</source>
+        <translation type="unfinished">選択した出力フォルダの使用可能な空き容量は %1 GB未満です。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="317"/>
+        <source>It is highly recommend to free up more diskspace before proceeding with the import!</source>
+        <translation type="unfinished">インポートする前に空き容量を増やすことを強く推奨します！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="369"/>
+        <source>Warning: Some of the required input files could not be found!</source>
+        <translation type="unfinished">警告: 入力ファイルの一部が見つかりませんでした！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="405"/>
+        <source>Analyzing file(s), please wait...</source>
+        <translation>ファイルを分析中、お待ちください...</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="410"/>
+        <source>Analysis Failed</source>
+        <translation>分析に失敗</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="410"/>
+        <source>Warning: The format of some of the input files could not be determined!</source>
+        <translation type="unfinished">警告: 一部の入力ファイルのfo-フォーマットを判別できませんでした！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="369"/>
+        <location filename="../../src/Dialog_CueImport.cpp" line="410"/>
+        <source>Continue Anyway</source>
+        <translation type="unfinished">それでも続行する</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="369"/>
+        <location filename="../../src/Dialog_CueImport.cpp" line="410"/>
+        <source>Abort</source>
+        <translation>中止</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="437"/>
+        <source>Splitting file(s), please wait...</source>
+        <translation>ファイルを分割中、お待ちください...</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/Dialog_CueImport.cpp" line="442"/>
+        <source>Process was aborted by the user after %n track(s)!</source>
+        <translation>
+            <numerusform>%n トラックの処理後、ユーザーによって処理が中止されました！</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="446"/>
+        <source>An unexpected error has occured while splitting the Cue Sheet!</source>
+        <translation>キューシートに従い分割中に予期しないエラーが発生しました！</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/Dialog_CueImport.cpp" line="450"/>
+        <source>Imported %n track(s) from the Cue Sheet.</source>
+        <translation>
+            <numerusform>キューシートに従い %n トラックがインポートされました。</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/Dialog_CueImport.cpp" line="450"/>
+        <source>Skipped %n track(s).</source>
+        <translation>
+            <numerusform>%n トラックが省略されました。</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_CueImport.cpp" line="451"/>
+        <source>Cue Sheet Completed</source>
+        <translation>キューシートに従いインポートが完了</translation>
+    </message>
+</context>
+<context>
+    <name>CueSheetImport</name>
+    <message>
+        <location filename="../../gui/CueSheetImport.ui" line="14"/>
+        <location filename="../../gui/CueSheetImport.ui" line="664"/>
+        <source>Import Cue Sheet</source>
+        <translation>キューシートに従いインポート</translation>
+    </message>
+    <message>
+        <location filename="../../gui/CueSheetImport.ui" line="189"/>
+        <source>Artist:</source>
+        <translation>アーティスト :</translation>
+    </message>
+    <message>
+        <location filename="../../gui/CueSheetImport.ui" line="241"/>
+        <source>Album:</source>
+        <translation>アルバム :</translation>
+    </message>
+    <message>
+        <location filename="../../gui/CueSheetImport.ui" line="415"/>
+        <source>Existing Source File</source>
+        <translation>存在する入力ファイル</translation>
+    </message>
+    <message>
+        <location filename="../../gui/CueSheetImport.ui" line="543"/>
+        <source>Missing Source File (Tracks will be skipped!)</source>
+        <translation>見つからない入力ファイル (省略されます)</translation>
+    </message>
+    <message>
+        <location filename="../../gui/CueSheetImport.ui" line="570"/>
+        <source> Output Directory </source>
+        <translation> 出力フォルダ </translation>
+    </message>
+    <message>
+        <location filename="../../gui/CueSheetImport.ui" line="594"/>
+        <source>Browse...</source>
+        <translation>参照...</translation>
+    </message>
+    <message>
+        <location filename="../../gui/CueSheetImport.ui" line="631"/>
+        <source>Load a different Cue Sheet</source>
+        <translation>別のキューシートを読み込む</translation>
+    </message>
+    <message>
+        <location filename="../../gui/CueSheetImport.ui" line="687"/>
+        <source>Discard</source>
+        <translation>キャンセル</translation>
+    </message>
+</context>
+<context>
+    <name>CueSheetModel</name>
+    <message>
+        <location filename="../../src/Model_CueSheet.cpp" line="207"/>
+        <source>No.</source>
+        <translation>No.</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_CueSheet.cpp" line="210"/>
+        <source>File / Track</source>
+        <translation>ファイル / トラック</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_CueSheet.cpp" line="213"/>
+        <source>Index</source>
+        <translation>インデックス</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_CueSheet.cpp" line="216"/>
+        <source>Duration</source>
+        <translation>長さ</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_CueSheet.cpp" line="242"/>
+        <source>File %1</source>
+        <translation>ファイル %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_CueSheet.cpp" line="258"/>
+        <source>Track %1</source>
+        <translation>トラック %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_CueSheet.cpp" line="267"/>
+        <location filename="../../src/Model_CueSheet.cpp" line="275"/>
+        <source>Unknown Artist</source>
+        <translation>不明なアーティスト</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_CueSheet.cpp" line="271"/>
+        <location filename="../../src/Model_CueSheet.cpp" line="275"/>
+        <source>Unknown Title</source>
+        <translation>不明なタイトル</translation>
+    </message>
+</context>
+<context>
+    <name>DecoderRegistry</name>
+    <message>
+        <location filename="../../src/Registry_Decoder.cpp" line="146"/>
+        <source>All supported types</source>
+        <translation>すべての対応ファイル</translation>
+    </message>
+    <message>
+        <location filename="../../src/Registry_Decoder.cpp" line="176"/>
+        <source>Playlists</source>
+        <translation>プレイリスト</translation>
+    </message>
+    <message>
+        <location filename="../../src/Registry_Decoder.cpp" line="177"/>
+        <source>All files</source>
+        <translation>すべてのファイル</translation>
+    </message>
+</context>
+<context>
+    <name>DiskObserverThread</name>
+    <message>
+        <location filename="../../src/Thread_DiskObserver.cpp" line="92"/>
+        <source>Low diskspace on drive &apos;%1&apos; detected (only %2 MB are free), problems can occur!</source>
+        <translation>ドライブ %1 の空き容量が少なくなっています ( %2 MB) 。エラーが発生するでしょう！</translation>
+    </message>
+</context>
+<context>
+    <name>DropBox</name>
+    <message>
+        <location filename="../../gui/DropBox.ui" line="14"/>
+        <source>LameXP - DropBox</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_DropBox.cpp" line="134"/>
+        <source>LameXP DropBox</source>
+        <translation>LameXP ドロップボックス</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_DropBox.cpp" line="134"/>
+        <source>You can add files to LameXP via Drag&amp;amp;Drop here!</source>
+        <translation>ここにドラッグ&amp;amp;ドロップして LameXP にファイルを追加しよう！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_DropBox.cpp" line="134"/>
+        <source>(Right-click to close the DropBox)</source>
+        <translation>(右クリックでこのドロップボックスを閉じます)</translation>
+    </message>
+</context>
+<context>
+    <name>FileExtsModel</name>
+    <message>
+        <location filename="../../src/Model_FileExts.cpp" line="140"/>
+        <source>File Extension</source>
+        <translation>ファイル拡張子</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_FileExts.cpp" line="142"/>
+        <source>Replace With</source>
+        <translation>置換する</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_FileExts.cpp" line="189"/>
+        <source>Select file extensions to overwrite:</source>
+        <translation>上書きするファイル拡張子を選択:</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_FileExts.cpp" line="208"/>
+        <source>Enter the new file extension:</source>
+        <translation>新しいファイル拡張子を入力:</translation>
+    </message>
+</context>
+<context>
+    <name>FileListModel</name>
+    <message>
+        <location filename="../../src/Model_FileList.cpp" line="118"/>
+        <source>Title</source>
+        <translation>タイトル</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_FileList.cpp" line="121"/>
+        <source>Full Path</source>
+        <translation>フルパス</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_FileList.cpp" line="347"/>
+        <source>(System Default)</source>
+        <translation>(システムの規定)</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_FileList.cpp" line="354"/>
+        <source>Select ANSI Codepage for CSV file:</source>
+        <translation>CSVファイルのANSIコードページ(文字コード)を選択:</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_FileList.cpp" line="355"/>
+        <source>OK</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_FileList.cpp" line="356"/>
+        <source>Cancel</source>
+        <translation>キャンセル</translation>
+    </message>
+</context>
+<context>
+    <name>LogViewDialog</name>
+    <message>
+        <location filename="../../gui/LogViewDialog.ui" line="23"/>
+        <source>Log View</source>
+        <translation>ログを開く</translation>
+    </message>
+    <message>
+        <location filename="../../gui/LogViewDialog.ui" line="308"/>
+        <source>Discard</source>
+        <translation>閉じる</translation>
+    </message>
+    <message>
+        <location filename="../../gui/LogViewDialog.ui" line="331"/>
+        <source>Save to File...</source>
+        <translation>ファイルに保存...</translation>
+    </message>
+    <message>
+        <location filename="../../gui/LogViewDialog.ui" line="367"/>
+        <source>Copy to Clipboard</source>
+        <translation>クリップボードにコピー</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_LogView.cpp" line="53"/>
+        <source>Log File</source>
+        <translation>ログファイル</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_LogView.cpp" line="53"/>
+        <source>The log file shows detailed information about the selected job.</source>
+        <translation>ログファイルには、選択された作業の詳細情報が表示されます。</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="14"/>
+        <source>LameXP - Audio Encoder Front-end</source>
+        <translation type="unfinished">LameXP - オーディオエンコードフロントエンド</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="50"/>
+        <location filename="../../gui/MainWindow.ui" line="4844"/>
+        <source>Source Files</source>
+        <translation>入力ファイル</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="94"/>
+        <source>Add File(s)</source>
+        <translation>ファイルの追加</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="117"/>
+        <source>Remove</source>
+        <translation>除去</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="140"/>
+        <source>Clear</source>
+        <translation>クリア</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="242"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1239"/>
+        <source>Show Details</source>
+        <translation>詳細を表示</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="274"/>
+        <location filename="../../gui/MainWindow.ui" line="4852"/>
+        <source>Output Directory</source>
+        <translation>出力フォルダ</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="365"/>
+        <source>Up One Level</source>
+        <translation>階層を上に</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="387"/>
+        <source>Edit Output Path</source>
+        <translation>出力先パスの編集</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="409"/>
+        <source>Show Favorites</source>
+        <translation>お気に入りの表示</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="445"/>
+        <source>Goto Home Folder</source>
+        <translation>ユーザーのフォルダへ</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="468"/>
+        <source>Goto Music Folder</source>
+        <translation>ミュージックフォルダへ</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="491"/>
+        <source>Goto Desktop Folder</source>
+        <translation>デスクトップへ</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="527"/>
+        <source>Make New Folder</source>
+        <translation>新規フォルダ作成</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="567"/>
+        <source>Save output files to the same location where the input file is located</source>
+        <translation>入力ファイルと同じフォルダに出力ファイルを保存</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="590"/>
+        <source>Prepend relative source file path to output file</source>
+        <translation>入力されたファイルパスと相対的なパスに出力する</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="606"/>
+        <location filename="../../gui/MainWindow.ui" line="4868"/>
+        <source>Meta Data</source>
+        <translation type="unfinished">メタ情報</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="620"/>
+        <source> Meta Information </source>
+        <translation type="unfinished"> メタ情報 </translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="654"/>
+        <source>Edit</source>
+        <translation>編集</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="671"/>
+        <source>Note: Meta information you enter here will &lt;u&gt;supersede&lt;/u&gt; data from the source!</source>
+        <translation>注: ここに入力したメタ情報は、入力ファイルからの情報より&lt;u&gt;優先されます&lt;/u&gt;！</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="706"/>
+        <location filename="../../gui/MainWindow.ui" line="1391"/>
+        <source>Reset</source>
+        <translation type="unfinished">リセット</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="732"/>
+        <source> Options </source>
+        <translation type="unfinished"> オプション </translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="746"/>
+        <source>Automatically generate playlist file (.m3u)</source>
+        <translation type="unfinished">プレイリストファイル (.m3u) を自動生成</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="762"/>
+        <source>Write meta information to encoded files</source>
+        <translation type="unfinished">エンコードされたファイルにメタ情報を書きこむ</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="784"/>
+        <location filename="../../gui/MainWindow.ui" line="4860"/>
+        <source>Compression</source>
+        <translation type="unfinished">圧縮</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="804"/>
+        <source> Encoder / Format </source>
+        <translation type="unfinished"> エンコーダー / 形式 </translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="828"/>
+        <source>MP3</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="851"/>
+        <source>Ogg/Vorbis</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="891"/>
+        <source>AAC/MP4</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="991"/>
+        <source>PCM/Wave</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="951"/>
+        <source>A/52</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="971"/>
+        <source>DCA</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="911"/>
+        <source>FLAC</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="871"/>
+        <source>Opus</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="931"/>
+        <source>APE</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1028"/>
+        <source> Rate Control Method </source>
+        <translation type="unfinished"> レート制御法 </translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1052"/>
+        <source>Quality-based (VBR)</source>
+        <translation type="unfinished">品質ベース (VBR)</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1075"/>
+        <source>Average Bitrate (ABR)</source>
+        <translation type="unfinished">平均ビットレート (ABR)</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1095"/>
+        <source>Constant Bitrate (CBR)</source>
+        <translation type="unfinished">一定のビットレート (CBR)</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1132"/>
+        <source> Quality / Bitrate </source>
+        <translation type="unfinished"> 品質 / ビットレート </translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1171"/>
+        <source>Minimum</source>
+        <translation type="unfinished">最高</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1181"/>
+        <source>Maximum</source>
+        <translation type="unfinished">最低</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1461"/>
+        <source>Show Help</source>
+        <translation type="unfinished">ヘルプの表示</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1493"/>
+        <location filename="../../gui/MainWindow.ui" line="4876"/>
+        <source>Advanced Options</source>
+        <translation type="unfinished">詳細設定</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1528"/>
+        <source> Bitrate Management (LAME and OggEnc2) </source>
+        <translation> ビットレート管理 (LAME と OggEnc2) </translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1568"/>
+        <source>Enable Bitrate Management</source>
+        <translation type="unfinished">ビットレート管理を有効</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1639"/>
+        <source>Minimum (kbps):</source>
+        <translation type="unfinished">最小 (kbps):</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1652"/>
+        <source>Maximum (kbps):</source>
+        <translation type="unfinished">最大 (kbps):</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1673"/>
+        <source> LAME Algorithm Quality </source>
+        <translation type="unfinished"> LAMEのアルゴリズムによる品質 </translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1713"/>
+        <source>Faster Processing</source>
+        <translation>高速処理</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1736"/>
+        <source>Better quality</source>
+        <translation>高品質</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1802"/>
+        <source>Warning: Audio quality will be very poor. Please do &lt;u&gt;not&lt;/u&gt; complain about audio quality!</source>
+        <translation>警告 : 音質は非常に悪いです。音質について文句を&lt;u&gt;言わないで&lt;/u&gt;！</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1829"/>
+        <source>Warning: Processing speed will be very slow. Please do &lt;u&gt;not&lt;/u&gt; complain about processing speed!</source>
+        <translation type="unfinished">警告 : 処理速度が非常に遅いでしょう。処理速度について文句を&lt;u&gt;言わないで&lt;/u&gt;！</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1871"/>
+        <source>Channel Mode / Sampling Rate</source>
+        <translation>チャンネルモード / サンプルレート</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1883"/>
+        <location filename="../../gui/MainWindow.ui" line="1940"/>
+        <source>Auto Select (Default)</source>
+        <translation type="unfinished">自動選択 (デフォルト)</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1888"/>
+        <source>Joint Stereo</source>
+        <translation>ジョイントステレオ</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1893"/>
+        <source>Forced Joint Stereo</source>
+        <translation>強制的にジョイントステレオ</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1898"/>
+        <source>Simple</source>
+        <translation type="unfinished">シンプル</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1903"/>
+        <source>Dual Mono</source>
+        <translation type="unfinished">デュアルモノ（それぞれ独立）</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1908"/>
+        <source>Mono</source>
+        <translation>モノ</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1916"/>
+        <source>MP3 Channel Mode:</source>
+        <translation type="unfinished">MP3チャンネルモード :</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1926"/>
+        <source>Sampling Rate (Hz):</source>
+        <translation>サンプルレート (Hz):</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1945"/>
+        <source>16.000</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1950"/>
+        <source>22.050</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1955"/>
+        <source>24.000</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1960"/>
+        <source>32.000</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1965"/>
+        <source>44.100</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="1970"/>
+        <source>48.000</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="2071"/>
+        <source>Enforce Stereo Downmix of Surround (Multi-Channel) Sources</source>
+        <translation type="unfinished">強制的にサラウンド音源 (多数チャンネル) をステレオでダウンミックスする</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="2105"/>
+        <source>AAC Encoder-Options</source>
+        <translation type="unfinished">AACエンコーダーのオプション</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="2113"/>
+        <source>Enable 2-Pass Processing (ABR Mode)</source>
+        <translation type="unfinished">2パスで処理 (ABR)</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="2149"/>
+        <source>Select AAC Profile:</source>
+        <translation type="unfinished">AACのプロファイルの選択:</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="2163"/>
+        <source>Auto Select (Recommended)</source>
+        <translation type="unfinished">自動選択 (推奨)</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="2168"/>
+        <source>Enforce LC-AAC</source>
+        <translation type="unfinished">LC-AAC を強制選択</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="2173"/>
+        <source>Enforce HE-AAC (AAC + SBR)</source>
+        <translation type="unfinished">HE-AAC (AAC + SBR) を強制選択</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="2178"/>
+        <source>Enforce HE-AAC v2 (AAC + SBR + PS)</source>
+        <translation type="unfinished">HE-AAC v2 (AAC + SBR + PS) を強制選択</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="2258"/>
+        <source> Volume Normalization </source>
+        <translation type="unfinished"> ボリュームノーマライゼーション (音量正規化) </translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="2266"/>
+        <source>Enable Normalization Filter</source>
+        <translation type="unfinished">ボリュームノーマライゼーションを使用</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="2327"/>
+        <source>Peak Volume (dB):</source>
+        <translation type="unfinished">最大音量 (dB):</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="2430"/>
+        <source>Enable Dynamic Normalization</source>
+        <translation type="unfinished">ダイナミックノーマライゼーション</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="2437"/>
+        <source>Window Size:</source>
+        <translation type="unfinished">ウィンドウサイズ:</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="2469"/>
+        <source>Enable channel-coupling, i.e. amplify all channels of a multi-channel file by the same amount</source>
+        <translation type="unfinished">チャンネルカップリング: 複数のチャンネルのファイルのすべてのチャンネルを同じ音量で増幅する</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="2490"/>
+        <source> Tone Adjustment </source>
+        <translation type="unfinished"> トーンの調整 </translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="2588"/>
+        <source>Adjust Treble (dB):</source>
+        <translation type="unfinished">高音域 (dB):</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="2598"/>
+        <source>Adjust Bass (dB):</source>
+        <translation type="unfinished">低音域 (dB):</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="2668"/>
+        <source> Custom Encoder Parameters </source>
+        <translation type="unfinished"> エンコーダーの引数のカスタマイズ </translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="2684"/>
+        <location filename="../../gui/MainWindow.ui" line="2699"/>
+        <location filename="../../gui/MainWindow.ui" line="2714"/>
+        <location filename="../../gui/MainWindow.ui" line="2729"/>
+        <location filename="../../gui/MainWindow.ui" line="2882"/>
+        <location filename="../../gui/MainWindow.ui" line="2976"/>
+        <source>You can enter custom parameters here!</source>
+        <translation type="unfinished">ここにお好みにカスタマイズするための引数を入力！</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="2736"/>
+        <source>Lame MP3:</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="2743"/>
+        <source>OggEnc2:</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="2750"/>
+        <source>MPEG-4 AAC:</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="2757"/>
+        <source>FLAC:</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="2846"/>
+        <source>Warning: Custom parameters won&apos;t be checked at all. Use them at your own risk !!!</source>
+        <translation type="unfinished">警告: カスタムの引数はまったくチェックされません。自己責任で使用してください！</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="2889"/>
+        <source>Aften A/52:</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="2961"/>
+        <source>OpusEnc:</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3007"/>
+        <source> Multi-Threading </source>
+        <translation> マルチスレッド </translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3104"/>
+        <source>Choose the number of parallel instances based on the number of CPU cores (Recommended)</source>
+        <translation type="unfinished">並列インスタンスの数をCPUのコア数で選ぶ (推奨)</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3111"/>
+        <source>Fewer Instances</source>
+        <translation type="unfinished">インスタンス少</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3134"/>
+        <source>More Instances</source>
+        <translation type="unfinished">インスタンス多</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3171"/>
+        <source> Temp Directory </source>
+        <translation type="unfinished"> Tempフォルダ </translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3186"/>
+        <source>Browse...</source>
+        <translation>参照...</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3203"/>
+        <source>Store temporary files in your system&apos;s default TEMP directory (Recommended)</source>
+        <translation type="unfinished">システム既定のTEMPフォルダに一時ファイルを保存 (推奨)</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3301"/>
+        <source> Aften A/52 Options </source>
+        <translation type="unfinished"> Aften A/52 のオプション </translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3313"/>
+        <source>Film Light</source>
+        <translation>映画ライト</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3318"/>
+        <source>Film Standard</source>
+        <translation>映画標準</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3323"/>
+        <source>Music Light</source>
+        <translation>音楽ライト</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3328"/>
+        <source>Music Standard</source>
+        <translation>音楽標準</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3333"/>
+        <source>Speech</source>
+        <translation>演説</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3338"/>
+        <source>None (Default)</source>
+        <translation>なし (規定)</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3350"/>
+        <source>Auto Select</source>
+        <translation>自動選択</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3355"/>
+        <source>1+1 (Ch1,Ch2)</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3360"/>
+        <source>1/0 (C)</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3365"/>
+        <source>2/0 (L,R)</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3370"/>
+        <source>3/0 (L,R,C)</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3375"/>
+        <source>2/1 (L,R,S)</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3380"/>
+        <source>3/1 (L,R,C,S)</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3385"/>
+        <source>2/2 (L,R,SL,SR)</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3390"/>
+        <source>3/2 (L,R,C,SL,SR)</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3398"/>
+        <source>Audio Coding Mode:</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3405"/>
+        <source>Dynamic Range Compression:</source>
+        <translation type="unfinished">圧縮の動的レンジ:</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3521"/>
+        <source>Fast Bit Allocation (Less Accurate)</source>
+        <translation type="unfinished">高速ビット割り当て (正確性低下)</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3528"/>
+        <source>Exponent Search Size:</source>
+        <translation type="unfinished">検索サイズの指定:</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3562"/>
+        <source> Rename Output Files </source>
+        <translation> 出力ファイルの改名 </translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3626"/>
+        <source>Enter the pattern to rename the output files here!</source>
+        <translation>ここに出力ファイルの改名パターンを入力！</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3665"/>
+        <source>Rename Output Files</source>
+        <translation>出力ファイルを改名する</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3694"/>
+        <source>&lt;a href=&quot;reset&quot;&gt;Reset&lt;/a&gt; &amp;nbsp; &lt;a href=&quot;#&quot;&gt;Show List of Macros&lt;/a&gt;</source>
+        <translation type="unfinished">&lt;a href=&quot;reset&quot;&gt;リセット&lt;/a&gt; &amp;nbsp; &lt;a href=&quot;#&quot;&gt;マクロの一覧を表示&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3726"/>
+        <source>Rename Pattern:</source>
+        <translation>改名パターン:</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3739"/>
+        <source>Example File Name:</source>
+        <translation>ファイル名の例示:</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3776"/>
+        <source>Replacement:</source>
+        <translation>置換:</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3789"/>
+        <source>Search Pattern:</source>
+        <translation>検索パターン:</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3818"/>
+        <source>&lt;a href=&quot;regexp&quot;&gt;Regular Expression Info&lt;/a&gt;</source>
+        <translation>&lt;a href=&quot;regexp&quot;&gt;正規表現の情報サイト(英)&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3844"/>
+        <source>Replace all Matching Elements</source>
+        <translation type="unfinished">すべての一致要素を置換</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3894"/>
+        <source>Enter the desired search pattern (regular expression) here!</source>
+        <translation>ここにご希望の検索パターン (正規表現) を入力！</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3941"/>
+        <source>Enter replacement text here! It may contain backreferences.</source>
+        <translation type="unfinished">ここに置換文字列を入力！後方参照も使えます。</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="3992"/>
+        <source>Add Overwrite </source>
+        <translation type="unfinished">上書きを追加 </translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4003"/>
+        <source>Remove Overwrite </source>
+        <translation type="unfinished">除去 </translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4040"/>
+        <source>Rename Files </source>
+        <translation type="unfinished">ファイルの改名 </translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4057"/>
+        <source>Regular Expressions </source>
+        <translation type="unfinished">正規表現 </translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4071"/>
+        <source>File Extensions </source>
+        <translation>ファイル拡張子 </translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4109"/>
+        <source> Opus Encoder Options </source>
+        <translation type="unfinished"> OPUSエンコーダーのオプション </translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4149"/>
+        <source>Encoding Complexity:</source>
+        <translation type="unfinished">エンコードの複雑さ:</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4191"/>
+        <source>Frame Size:</source>
+        <translation type="unfinished">フレームサイズ:</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4279"/>
+        <source>Disable Opus-Decoder Resampling (i.e. always output as 48.000 Hz)</source>
+        <translation type="unfinished">Opusデコーダー再サンプリングを無効に (常に 48.000Hz で出力)</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4329"/>
+        <source> File Operations </source>
+        <translation type="unfinished"> ファイルの操作 </translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4350"/>
+        <source>Overwrite Existing File</source>
+        <translation>既存のファイルを上書き</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4357"/>
+        <source>Skip File</source>
+        <translation type="unfinished">飛ばす (省略する)</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4367"/>
+        <source>Keep Both Files (Default)</source>
+        <translation type="unfinished">両方のファイルを保存 (規定)</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4377"/>
+        <source>If Target File Already Exists:</source>
+        <translation type="unfinished">対象のファイルが既に存在する場合:</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4487"/>
+        <source>Apply the &quot;creation&quot; and &quot;last modified&quot; date/time of the original file to the converted file</source>
+        <translation>変換したファイルを、入力元ファイルの「作成日時」と「更新日時」にする</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4547"/>
+        <source>Reset Advanced Options </source>
+        <translation>詳細設定の初期化 </translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4613"/>
+        <source> Encode Now!</source>
+        <translation> 今すぐエンコード！</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4655"/>
+        <location filename="../../gui/MainWindow.ui" line="4827"/>
+        <source>About...</source>
+        <translation>このソフト...</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4691"/>
+        <source> Exit Program</source>
+        <translation> プログラム終了</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4723"/>
+        <source>File</source>
+        <translation>ファイル</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4737"/>
+        <source>?</source>
+        <translation>?</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4755"/>
+        <source>View</source>
+        <translation>ビュー</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4759"/>
+        <source>Style</source>
+        <translation>スタイル</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4773"/>
+        <source>Language</source>
+        <translation>言語</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4792"/>
+        <source>Tools</source>
+        <translation>ツール</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4796"/>
+        <source>Configuration</source>
+        <translation>設定</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4836"/>
+        <source>Quit</source>
+        <translation>終了</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4885"/>
+        <source>Open File(s)...</source>
+        <translation>ファイルを開く...</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4894"/>
+        <source>Official LameXP Project Web-Site</source>
+        <translation>LameXPプロジェクト公式サイト</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4897"/>
+        <source>Visit Official Web-Site</source>
+        <translation type="unfinished">公式サイト</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4906"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1237"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1518"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1545"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1573"/>
+        <source>Check for Updates</source>
+        <translation>アップデートの確認</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4915"/>
+        <source>Open Folder...</source>
+        <translation>フォルダを開く...</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4924"/>
+        <source>Clear All</source>
+        <translation>すべてクリア</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4935"/>
+        <source>Plastique</source>
+        <translation>プラスチック</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4943"/>
+        <source>Cleanlooks</source>
+        <translation>すっきり</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4951"/>
+        <source>Windows Vista (&quot;Aero&quot;)</source>
+        <translation>Windows Vista (Aero)</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4959"/>
+        <source>Windows Classic</source>
+        <translation>Windows クラシック</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4967"/>
+        <source>Windows XP (&quot;Luna&quot;)</source>
+        <translation>Windows XP (Luna)</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4975"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2075"/>
+        <source>Disable Update Reminder</source>
+        <translation>アップデートの確認を促さない</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4983"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2101"/>
+        <source>Disable Sound Effects</source>
+        <translation type="unfinished">効果音を無効にする</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="4992"/>
+        <source>Install WMA Decoder</source>
+        <translation type="unfinished">WMAデコーダーをインストール</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="5000"/>
+        <source>Disable Nero AAC Notifications</source>
+        <translation type="unfinished">Nero AAC の通知をしない</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="5009"/>
+        <source>Show DropBox</source>
+        <translation type="unfinished">ドロップボックスを表示</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="5033"/>
+        <source>From File...</source>
+        <translation type="unfinished">ファイルから...</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="5042"/>
+        <source>Encode!</source>
+        <translation>エンコード！</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="5050"/>
+        <source>Disable Shell Integration</source>
+        <translation type="unfinished">シェルに統合しない</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="5059"/>
+        <source>LameXP User&apos;s Manual</source>
+        <translation>LameXP 説明書</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="5068"/>
+        <source>Changelog</source>
+        <translation>更新履歴</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="5077"/>
+        <source>Translator&apos;s Guide</source>
+        <translation>翻訳手引き</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="5086"/>
+        <source>Help &amp;&amp; Support</source>
+        <translation>ヘルプとサポート</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="5095"/>
+        <source>Open Folder Recursively...</source>
+        <translation type="unfinished">サブフォルダまですべて開く...</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="5103"/>
+        <source>Check for Beta Updates</source>
+        <translation type="unfinished">ベータ版のアップデートも確認</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="5112"/>
+        <source>Import Cue Sheet</source>
+        <translation>キューシートのインポート</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="5120"/>
+        <source>Disable Slow Startup Notifications</source>
+        <translation type="unfinished">起動が遅い場合の通知を無効</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="5128"/>
+        <source>Hibernate Computer On Shutdown</source>
+        <translation type="unfinished">シャットダウンでパソコンを休止状態にする</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="5137"/>
+        <source>MuldeR&apos;s OpenSource Projects</source>
+        <translation type="unfinished">MuldeR のオープンソースプロジェクト</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="5146"/>
+        <source>Report a Bug (GitHub)</source>
+        <translation>バグ報告 (GitHub)</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MainWindow.ui" line="5155"/>
+        <source>Hydrogenaudio Knowledgebase</source>
+        <translation type="unfinished">Hydrogenaudio 知識データベース</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="848"/>
+        <source>Adding file(s), please wait...</source>
+        <translation type="unfinished">ファイルを追加、お待ちください...</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="859"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="4278"/>
+        <source>Access Denied</source>
+        <translation type="unfinished">アクセス亜拒否されました</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/Dialog_MainWindow.cpp" line="859"/>
+        <source>%n file(s) have been rejected, because read access was not granted!</source>
+        <translation type="unfinished">
+            <numerusform>%n 個のファイルが処理できませんでした。読み取りアクセスが許可されていません！</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="859"/>
+        <source>This usually means the file is locked by another process.</source>
+        <translation type="unfinished">ほかのプロセスによってファイルがロックされているかもしれません。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="863"/>
+        <source>CDDA Files</source>
+        <translation type="unfinished">CDDAファイル</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/Dialog_MainWindow.cpp" line="863"/>
+        <source>%n file(s) have been rejected, because they are dummy CDDA files!</source>
+        <translation type="unfinished">
+            <numerusform>%n 個のファイルが処理できませんでした。ダミーのCDDAファイルでした！</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="863"/>
+        <source>Sorry, LameXP cannot extract audio tracks from an Audio-CD at present.</source>
+        <translation type="unfinished">すみません。オーディオCDからの音声トラックの抽出はできません。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="863"/>
+        <source>We recommend using %1 for that purpose.</source>
+        <translation type="unfinished">その用途には %1 の使用をおすすめします。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="867"/>
+        <source>Cue Sheet</source>
+        <translation>キューシート</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/Dialog_MainWindow.cpp" line="867"/>
+        <source>%n file(s) have been rejected, because they appear to be Cue Sheet images!</source>
+        <translation>
+            <numerusform>%n 個のファイルが処理できませんでした。キューシートのようです！</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="867"/>
+        <source>Please use LameXP&apos;s Cue Sheet wizard for importing Cue Sheet files.</source>
+        <translation>キューシートファイルのインポートにはLameXPのキューシート用のウィザードをお使いください。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="871"/>
+        <source>Files Rejected</source>
+        <translation type="unfinished">不適切なファイル</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/Dialog_MainWindow.cpp" line="871"/>
+        <source>%n file(s) have been rejected, because the file format could not be recognized!</source>
+        <translation type="unfinished">
+            <numerusform>%n ファイルは認識できませんでした。対応するファイル形式ではありません！</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="871"/>
+        <source>This usually means the file is damaged or the file format is not supported.</source>
+        <translation type="unfinished">ファイルが破損しているか、対応していません。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="886"/>
+        <source>Scanning folder(s) for files, please wait...</source>
+        <translation type="unfinished">フォルダをスキャン中、お待ちください...</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1229"/>
+        <source>DEMO VERSION</source>
+        <translation type="unfinished">デモ版</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1233"/>
+        <source>Initializing directory outline, please be patient...</source>
+        <translation type="unfinished">フォルダ構成の取得中、お待ちください...</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1234"/>
+        <source>You can drop in audio files here!</source>
+        <translation>ここに音声ファイルをドロップ！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1240"/>
+        <source>Open File in External Application</source>
+        <translation type="unfinished">関連付けされたプログラムでファイルを開く</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1241"/>
+        <source>Browse File Location</source>
+        <translation>ファイルのあるフォルダを開く</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1242"/>
+        <source>Browse Selected Folder</source>
+        <translation>選択したフォルダを開く</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1243"/>
+        <source>Refresh Directory Outline</source>
+        <translation>フォルダ構成の情報を更新</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1244"/>
+        <source>Go To Parent Directory</source>
+        <translation>上のフォルダ</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1245"/>
+        <source>Bookmark Current Output Folder</source>
+        <translation>現在の出力フォルダをお気に入りに登録</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1246"/>
+        <source>Export Meta Tags to CSV File</source>
+        <translation>メタタグをCSVファイルでエクスポート</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1247"/>
+        <source>Import Meta Tags from CSV File</source>
+        <translation>メタタグをCSVファイルでインポート</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1496"/>
+        <source>License Declined</source>
+        <translation type="unfinished">ライセンス条項の拒否</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1496"/>
+        <source>You have declined the license. Consequently the application will exit now!</source>
+        <translation type="unfinished">ライセンス条項の受託を拒否しましたね。なのですぐに終了します！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1496"/>
+        <source>Goodbye!</source>
+        <translation type="unfinished">さようなら！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1518"/>
+        <source>LameXP - Expired</source>
+        <translation type="unfinished">LameXP - 期限</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1518"/>
+        <source>This demo (pre-release) version of LameXP has expired at %1.</source>
+        <translation type="unfinished">この LameXP のデモ版 (正式公開前) です。有効期限は %1 です。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1518"/>
+        <source>LameXP is free software and release versions won&apos;t expire.</source>
+        <translation type="unfinished">LameXP はフリーソフトでリリース版の有効期限はありません。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1518"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1545"/>
+        <source>Exit Program</source>
+        <translation>プログラム終了</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1531"/>
+        <source>It seems that a bogus anti-virus software is slowing down the startup of LameXP.</source>
+        <translation type="unfinished">インチキなウイルス対策ソフトが LameXP の起動を遅くしているようです。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1532"/>
+        <source>Please refer to the %1 document for details and solutions!</source>
+        <translation type="unfinished">詳細と解決策については、%1 を参照してください！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1532"/>
+        <source>Manual</source>
+        <translation type="unfinished">マニュアル</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1533"/>
+        <source>Slow Startup</source>
+        <translation type="unfinished">起動が遅いです</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1533"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1598"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1677"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2248"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="4188"/>
+        <source>Discard</source>
+        <translation type="unfinished">閉じる</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1533"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1598"/>
+        <source>Don&apos;t Show Again</source>
+        <translation type="unfinished">再び表示しない</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1545"/>
+        <source>Urgent Update</source>
+        <translation type="unfinished">緊急アップデート</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1545"/>
+        <source>Your version of LameXP is more than a year old. Time for an update!</source>
+        <translation type="unfinished">お使いの LameXP のバージョンは1年以上前のものです。アップデートしましょう！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1545"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1759"/>
+        <source>Ignore</source>
+        <translation>無視</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1561"/>
+        <source>Skipping update check this time, please be patient...</source>
+        <translation type="unfinished">今回のアップデート確認は省略します、お待ちください...</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1573"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2077"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2087"/>
+        <source>Update Reminder</source>
+        <translation type="unfinished">アップデートリマインダー</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1573"/>
+        <source>Your last update check was more than 14 days ago. Check for updates now?</source>
+        <translation type="unfinished">前回のアップデート確認は14日以上前です。今すぐ更新確認をしますか？</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1573"/>
+        <source>Your did not check for LameXP updates yet. Check for updates now?</source>
+        <translation type="unfinished">LameXP のアップデートをまだ確認していません。今すぐ更新確認をしますか？</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1573"/>
+        <source>Postpone</source>
+        <translation type="unfinished">延期する</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1591"/>
+        <source>The Nero AAC encoder could not be found. AAC encoding support will be disabled.</source>
+        <translation type="unfinished">Nero AAC が見つかりません。 AAC エンコードの対応は無効化されています。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1592"/>
+        <source>Please put &apos;neroAacEnc.exe&apos;, &apos;neroAacDec.exe&apos; and &apos;neroAacTag.exe&apos; into the LameXP directory!</source>
+        <translation type="unfinished">LameXP のフォルダに neroAacEnc.exe neroAacDec.exe neroAacTag.exe を入れてください！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1593"/>
+        <source>Your LameXP install directory is located here:</source>
+        <translation type="unfinished">LameXP のインストール先 :</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1595"/>
+        <source>You can download the Nero AAC encoder for free from this website:</source>
+        <translation type="unfinished">Nero AAC encoder fore free の入手先 :</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1597"/>
+        <source>Note: Nero AAC encoder version %1 or newer is required to enable AAC encoding support!</source>
+        <translation type="unfinished">注: Nero AAC エンコーダーのバージョン %1 以上が、 AAC エンコードの対応に必要です！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1598"/>
+        <source>AAC Support Disabled</source>
+        <translation type="unfinished">AAC への対応が有効になっていません</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1729"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1786"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1796"/>
+        <source>LameXP</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1729"/>
+        <source>You must add at least one file to the list before proceeding!</source>
+        <translation type="unfinished">少なくとも、一覧にファイルを追加してからですよ！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1737"/>
+        <source>Not Found</source>
+        <translation type="unfinished">見つかりません</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1737"/>
+        <source>Your currently selected TEMP folder does not exist anymore:</source>
+        <translation type="unfinished">選択した TEMPフォルダがありません:</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1737"/>
+        <source>Restore Default</source>
+        <translation type="unfinished">初期設定に戻す</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1737"/>
+        <source>Cancel</source>
+        <translation>キャンセル</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1754"/>
+        <source>There are less than %1 GB of free diskspace available on your system&apos;s TEMP folder.</source>
+        <translation type="unfinished">システムのTEMPフォルダの使用可能な空き容量は %1 GB未満です。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1755"/>
+        <source>It is highly recommend to free up more diskspace before proceeding with the encode!</source>
+        <translation type="unfinished">エンコードする前に空き容量を増やすことを強く推奨します！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1756"/>
+        <source>Your TEMP folder is located at:</source>
+        <translation type="unfinished">TEMPフォルダの場所:</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1759"/>
+        <source>Low Diskspace Warning</source>
+        <translation type="unfinished">空き容量の警告</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1759"/>
+        <source>Abort Encoding Process</source>
+        <translation type="unfinished">エンコード処理を中止</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1759"/>
+        <source>Clean Disk Now</source>
+        <translation type="unfinished">今すぐディスクをクリーンアップ</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1767"/>
+        <source>Low Diskspace</source>
+        <translation type="unfinished">空き容量が少ない</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1767"/>
+        <source>You are proceeding with low diskspace. Problems might occur!</source>
+        <translation type="unfinished">空き容量が少ないため、問題が発生するかもしれません！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1786"/>
+        <source>Sorry, an unsupported encoder has been chosen!</source>
+        <translation type="unfinished">対応していないエンコーダーが選択されました！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1796"/>
+        <source>Cannot write to the selected output directory.</source>
+        <translation type="unfinished">選択した出力フォルダに書き込めません。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="1796"/>
+        <source>Please choose a different directory!</source>
+        <translation type="unfinished">別のフォルダを選択してください！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2039"/>
+        <source>Load Translation</source>
+        <translation>翻訳の読み込み</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2041"/>
+        <source>Translation Files</source>
+        <translation>翻訳ファイル</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2075"/>
+        <source>Do you really want to disable the update reminder?</source>
+        <translation type="unfinished">本当にアップデートリマインダーを無効にしますか？</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2075"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2101"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2127"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2153"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2246"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2283"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2309"/>
+        <source>Yes</source>
+        <translation>はい</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2075"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2101"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2127"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2153"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2246"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2283"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2309"/>
+        <source>No</source>
+        <translation>いいえ</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2077"/>
+        <source>The update reminder has been disabled.</source>
+        <translation type="unfinished">アップデートリマインダーは無効になっています。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2077"/>
+        <source>Please remember to check for updates at regular intervals!</source>
+        <translation type="unfinished">定期的にアップデートを確認してください！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2087"/>
+        <source>The update reminder has been re-enabled.</source>
+        <translation type="unfinished">アップデートリマインダーは再び有効にされました。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2101"/>
+        <source>Do you really want to disable all sound effects?</source>
+        <translation type="unfinished">本当にすべての効果音を無効にしますか？</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2103"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2113"/>
+        <source>Sound Effects</source>
+        <translation>効果音</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2103"/>
+        <source>All sound effects have been disabled.</source>
+        <translation type="unfinished">すべての効果音は無効に設定されました。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2113"/>
+        <source>The sound effects have been re-enabled.</source>
+        <translation type="unfinished">効果音は再び有効にされました。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2127"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2129"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2139"/>
+        <source>Nero AAC Notifications</source>
+        <translation type="unfinished">Nero AACの通知</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2127"/>
+        <source>Do you really want to disable all Nero AAC Encoder notifications?</source>
+        <translation type="unfinished">本当にNero AACエンコーダーの通知を無効にしますか？</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2129"/>
+        <source>All Nero AAC Encoder notifications have been disabled.</source>
+        <translation type="unfinished">すべてのNero AACエンコーダーの通知は無効に設定されました。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2139"/>
+        <source>The Nero AAC Encoder notifications have been re-enabled.</source>
+        <translation type="unfinished">Nero AACエンコーダーの通知は再び有効にされました。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2153"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2155"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2165"/>
+        <source>Slow Startup Notifications</source>
+        <translation type="unfinished">起動が遅い場合の通知</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2153"/>
+        <source>Do you really want to disable the slow startup notifications?</source>
+        <translation type="unfinished">本当に起動が遅い場合の通知を無効にしますか？</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2155"/>
+        <source>The slow startup notifications have been disabled.</source>
+        <translation type="unfinished">起動が遅い場合の通知は無効に設定されました。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2165"/>
+        <source>The slow startup notifications have been re-enabled.</source>
+        <translation type="unfinished">起動が遅い場合の通知は再び有効にされました。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2187"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2191"/>
+        <source>Open Cue Sheet</source>
+        <translation type="unfinished">キューシートを開く</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2187"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2193"/>
+        <source>Cue Sheet File</source>
+        <translation type="unfinished">キューシート</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2246"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2248"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2261"/>
+        <source>Beta Updates</source>
+        <translation type="unfinished">ベータ版アップデート</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2246"/>
+        <source>Do you really want LameXP to check for Beta (pre-release) updates?</source>
+        <translation type="unfinished">本当に LameXP のベータ版 (正式リリース前) のアップデートを確認しますか？</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2248"/>
+        <source>LameXP will check for Beta (pre-release) updates from now on.</source>
+        <translation type="unfinished">これからは、ベータ版 (正式リリース前) のアップデートを確認します。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2248"/>
+        <source>Check Now</source>
+        <translation>今すぐ確認</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2261"/>
+        <source>LameXP will &lt;i&gt;not&lt;/i&gt; check for Beta (pre-release) updates from now on.</source>
+        <translation type="unfinished">これからは、ベータ版 (正式リリース前) のアップデートを確認&lt;i&gt;しません&lt;/i&gt;。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2283"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2285"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2295"/>
+        <source>Hibernate Computer</source>
+        <translation type="unfinished">パソコンの休止状態の設定</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2283"/>
+        <source>Do you really want the computer to be hibernated on shutdown?</source>
+        <translation type="unfinished">本当にシャットダウン時にパソコンを休止状態をしますか？</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2285"/>
+        <source>LameXP will hibernate the computer on shutdown from now on.</source>
+        <translation type="unfinished">LameXP はシャットダウン時にパソコンを休止状態にします。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2295"/>
+        <source>LameXP will &lt;i&gt;not&lt;/i&gt; hibernate the computer on shutdown from now on.</source>
+        <translation type="unfinished">LameXP はシャットダウン時にパソコンを休止状態に&lt;i&gt;しません&lt;/i&gt;。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2309"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2312"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2323"/>
+        <source>Shell Integration</source>
+        <translation type="unfinished">シェルへの統合</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2309"/>
+        <source>Do you really want to disable the LameXP shell integration?</source>
+        <translation type="unfinished">本当に LameXP のシェルへの統合を無効にしますか？</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2312"/>
+        <source>The LameXP shell integration has been disabled.</source>
+        <translation type="unfinished">シェルへの統合を無効にしました。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2323"/>
+        <source>The LameXP shell integration has been re-enabled.</source>
+        <translation type="unfinished">シェルへの統合を再び有効にしました。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2393"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2402"/>
+        <source>Add file(s)</source>
+        <translation>ファイルの追加</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2432"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2436"/>
+        <source>Add Folder</source>
+        <translation>フォルダの追加</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2454"/>
+        <source>Filter Files</source>
+        <translation type="unfinished">ファイルフィルター</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2454"/>
+        <source>Select filename filter:</source>
+        <translation type="unfinished">ファイル名フィルターの選択:</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2670"/>
+        <source>Loading dropped files or folders, please wait...</source>
+        <translation type="unfinished">ドロップされたファイルやフォルダを読み込んでいます...</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2766"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2770"/>
+        <source>Save CSV file</source>
+        <translation>CSV ファイルを保存</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2766"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2773"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2816"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2822"/>
+        <source>CSV File</source>
+        <translation>CSV ファイル</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2787"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2790"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2793"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2796"/>
+        <source>CSV Export</source>
+        <translation type="unfinished">CSV でエクスポート</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2787"/>
+        <source>Sorry, there are no meta tags that can be exported!</source>
+        <translation type="unfinished">エクスポート可能なメタタグがありません！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2790"/>
+        <source>Sorry, failed to open CSV file for writing!</source>
+        <translation type="unfinished">書き込み時にCSVファイルが開けませんでした！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2793"/>
+        <source>Sorry, failed to write to the CSV file!</source>
+        <translation type="unfinished">CSVファイルへの書き込みに失敗しました！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2796"/>
+        <source>The CSV files was created successfully!</source>
+        <translation type="unfinished">CSVファイルが正常に作成されました！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2816"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2820"/>
+        <source>Open CSV file</source>
+        <translation type="unfinished">CSV ファイルを開く</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2836"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2839"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2842"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2845"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2848"/>
+        <source>CSV Import</source>
+        <translation type="unfinished">CSV のインポート</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2836"/>
+        <source>Sorry, failed to open CSV file for reading!</source>
+        <translation type="unfinished">読み込み時にCSVファイルを開くのに失敗しました！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2839"/>
+        <source>Sorry, failed to read from the CSV file!</source>
+        <translation type="unfinished">CSVファイルからの読み込みに失敗しました！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2842"/>
+        <source>Sorry, the CSV file does not contain any known fields!</source>
+        <translation type="unfinished">CSVファイルに認識フィールドがありません！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2845"/>
+        <source>CSV file is incomplete. Not all files were updated!</source>
+        <translation type="unfinished">CSVファイルが不完全です。更新されていないファイルがあります！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="2848"/>
+        <source>The CSV files was imported successfully!</source>
+        <translation>CSVファイルのインポートに成功しました！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="3027"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="3072"/>
+        <source>New Folder</source>
+        <translation type="unfinished">新規フォルダ</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="3072"/>
+        <source>Enter the name of the new folder:</source>
+        <translation type="unfinished">新しいフォルダの名前を入力:</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="3105"/>
+        <source>Failed to create folder</source>
+        <translation type="unfinished">フォルダ作成に失敗しました</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="3105"/>
+        <source>The new folder could not be created:</source>
+        <translation type="unfinished">新しいフォルダを作成できませんでした:</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="3105"/>
+        <source>Drive is read-only or insufficient access rights!</source>
+        <translation type="unfinished">ドライブが読み取り専用か、アクセス権限がありません！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="3582"/>
+        <source>Current Encoder: %1</source>
+        <translation>現在のエンコーダー: %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="3686"/>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="3689"/>
+        <source>Quality Level %1</source>
+        <translation>品質レベル %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="3692"/>
+        <source>Compression %1</source>
+        <translation>圧縮 %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="3695"/>
+        <source>Uncompressed</source>
+        <translation>非圧縮</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="3738"/>
+        <source>Best Quality (Slow)</source>
+        <translation>最高品質 (遅い)</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="3741"/>
+        <source>High Quality (Recommended)</source>
+        <translation>高品質 (推奨)</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="3744"/>
+        <source>Acceptable Quality (Fast)</source>
+        <translation>容認可能な品質 (早い)</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="3747"/>
+        <source>Poor Quality (Very Fast)</source>
+        <translation>低品質 (高速)</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="4177"/>
+        <source>File name without extension</source>
+        <translation>拡張子を除くファイル名</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="4178"/>
+        <source>Track number with leading zero</source>
+        <translation>先頭に 0 を付与したトラック番号</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="4179"/>
+        <source>Track title</source>
+        <translation>トラックのタイトル</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="4180"/>
+        <source>Artist name</source>
+        <translation>アーティスト名</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="4181"/>
+        <source>Album name</source>
+        <translation>アルバム名</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="4182"/>
+        <source>Year with (at least) four digits</source>
+        <translation>トラックのタイトル</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="4183"/>
+        <source>Comment</source>
+        <translation>コメント</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="4185"/>
+        <source>Characters forbidden in file names:</source>
+        <translation>ファイル名に使えない文字:</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="4188"/>
+        <source>Rename Macros</source>
+        <translation>改名用マクロ</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/Dialog_MainWindow.cpp" line="4235"/>
+        <source>%n Instance(s)</source>
+        <translation>
+            <numerusform>%n インスタンス</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="4278"/>
+        <source>Cannot write to the selected directory. Please choose another directory!</source>
+        <translation type="unfinished">選択したフォルダに書き込めません。 違うフォルダを選択してください！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="4415"/>
+        <source>Overwrite Mode</source>
+        <translation>上書きモード</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="4415"/>
+        <source>Warning: This mode may overwrite existing files with no way to revert!</source>
+        <translation>警告: この方法では元に戻せない方法で既存のファイルが上書きされます！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="4415"/>
+        <source>Continue</source>
+        <translation>続行</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="4415"/>
+        <source>Revert</source>
+        <translation>元に戻す</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="4508"/>
+        <source>Already Running</source>
+        <translation>既に起動中</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MainWindow.cpp" line="4508"/>
+        <source>LameXP is already running, please use the running instance!</source>
+        <translation type="unfinished">LameXP は既に起動中です。 そちらをご利用ください！</translation>
+    </message>
+</context>
+<context>
+    <name>MetaInfo</name>
+    <message>
+        <location filename="../../gui/MetaInfo.ui" line="14"/>
+        <source>Meta Information</source>
+        <translation>メタ情報</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MetaInfo.ui" line="321"/>
+        <source>Artwork</source>
+        <translation>アートワーク</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MetaInfo.ui" line="419"/>
+        <source>Edit</source>
+        <translation>編集</translation>
+    </message>
+    <message>
+        <location filename="../../gui/MetaInfo.ui" line="445"/>
+        <source>Close</source>
+        <translation>閉じる</translation>
+    </message>
+</context>
+<context>
+    <name>MetaInfoDialog</name>
+    <message>
+        <location filename="../../src/Dialog_MetaInfo.cpp" line="73"/>
+        <source>Edit this Information</source>
+        <translation>この情報を編集</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MetaInfo.cpp" line="74"/>
+        <source>Copy everything to Meta Info tab</source>
+        <translation>メタ情報のタブへ全項目をコピー</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MetaInfo.cpp" line="75"/>
+        <source>Clear all Meta Info</source>
+        <translation>すべてのメタ情報を消去</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MetaInfo.cpp" line="76"/>
+        <source>Load Artwork From File</source>
+        <translation>アートワークをファイルから読み込む</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MetaInfo.cpp" line="77"/>
+        <source>Clear Artwork</source>
+        <translation>アートワークの消去</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MetaInfo.cpp" line="93"/>
+        <source>Meta Information</source>
+        <translation>メタ情報</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MetaInfo.cpp" line="93"/>
+        <source>The following meta information have been extracted from the original file.</source>
+        <translation>次のメタ情報が入力ファイルから抽出されています。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MetaInfo.cpp" line="112"/>
+        <source>Meta Information: %1</source>
+        <translation>メタ情報 : %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MetaInfo.cpp" line="166"/>
+        <source>Load Artwork</source>
+        <translation>アートワークの読み込み</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MetaInfo.cpp" line="182"/>
+        <source>Artwork Error</source>
+        <translation>アートワークのエラー</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_MetaInfo.cpp" line="182"/>
+        <source>Sorry, failed to load artwork from selected file!</source>
+        <translation>選択したファイルからアートワークが読み込めません！</translation>
+    </message>
+</context>
+<context>
+    <name>MetaInfoModel</name>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="50"/>
+        <location filename="../../src/Model_MetaInfo.cpp" line="60"/>
+        <location filename="../../src/Model_MetaInfo.cpp" line="450"/>
+        <source>Unknown</source>
+        <translation>不明</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="51"/>
+        <location filename="../../src/Model_MetaInfo.cpp" line="61"/>
+        <location filename="../../src/Model_MetaInfo.cpp" line="451"/>
+        <source>Not Specified</source>
+        <translation>指定なし</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="89"/>
+        <source>Full Path</source>
+        <translation>フルパス</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="92"/>
+        <source>Format</source>
+        <translation>フォーマット</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="95"/>
+        <source>Container</source>
+        <translation>コンテナ</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="98"/>
+        <source>Compression</source>
+        <translation>圧縮</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="101"/>
+        <source>Duration</source>
+        <translation>長さ</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="104"/>
+        <source>Title</source>
+        <translation>タイトル</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="107"/>
+        <source>Artist</source>
+        <translation>アーティスト</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="110"/>
+        <source>Album</source>
+        <translation>アルバム</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="113"/>
+        <source>Genre</source>
+        <translation>ジャンル</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="116"/>
+        <source>Year</source>
+        <translation>年</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="119"/>
+        <source>Position</source>
+        <translation>曲番</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="119"/>
+        <location filename="../../src/Model_MetaInfo.cpp" line="409"/>
+        <source>Generate from list position</source>
+        <translation>一覧の順に曲番を生成</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="122"/>
+        <source>Comment</source>
+        <translation>コメント</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="234"/>
+        <source>Property</source>
+        <translation>プロパティ</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="237"/>
+        <source>Value</source>
+        <translation>値</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="309"/>
+        <source>Unspecified</source>
+        <translation type="unfinished">詳細不明</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="313"/>
+        <source>OK</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="314"/>
+        <source>Cancel</source>
+        <translation>キャンセル</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="320"/>
+        <location filename="../../src/Model_MetaInfo.cpp" line="328"/>
+        <source>Edit Title</source>
+        <translation>タイトルの編集</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="321"/>
+        <source>Please enter the title for this file:</source>
+        <translation>このファイルのタイトルを入力してください :</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="328"/>
+        <source>The title must not be empty. Generating title from file name!</source>
+        <translation>タイトルは空にしないように。ファイル名からタイトルを生成します！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="339"/>
+        <source>Edit Artist</source>
+        <translation>アーティストの編集</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="340"/>
+        <source>Please enter the artist for this file:</source>
+        <translation>このファイルのアーティストを入力してください :</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="351"/>
+        <source>Edit Album</source>
+        <translation>アルバムの編集</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="352"/>
+        <source>Please enter the album for this file:</source>
+        <translation>このファイルのアルバムを入力してください :</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="363"/>
+        <source>Edit Genre</source>
+        <translation>ジャンルの編集</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="364"/>
+        <source>Please enter the genre for this file:</source>
+        <translation>このファイルのジャンルを入力してください :</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="377"/>
+        <source>Edit Year</source>
+        <translation>年の編集</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="378"/>
+        <source>Please enter the year for this file:</source>
+        <translation>このファイルの年を入力してください :</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="393"/>
+        <location filename="../../src/Model_MetaInfo.cpp" line="410"/>
+        <source>Edit Position</source>
+        <translation>曲番の編集</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="394"/>
+        <location filename="../../src/Model_MetaInfo.cpp" line="411"/>
+        <source>Please enter the position (track no.) for this file:</source>
+        <translation type="unfinished">このファイルの曲番 (トラック番号) を入力してください :</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="409"/>
+        <source>Unspecified (copy from source file)</source>
+        <translation>指定しない (入力ファイルの情報をコピー)</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="424"/>
+        <source>Edit Comment</source>
+        <translation>コメントの編集</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="425"/>
+        <source>Please enter the comment for this file:</source>
+        <translation>このファイルのコメントを入力してください :</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="426"/>
+        <location filename="../../src/Model_MetaInfo.cpp" line="461"/>
+        <source>Encoded with LameXP</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="436"/>
+        <source>Not editable</source>
+        <translation>編集不可能</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_MetaInfo.cpp" line="436"/>
+        <source>Sorry, this property of the source file cannot be edited!</source>
+        <translation>入力ファイルのこのプロパティは編集できません！</translation>
+    </message>
+</context>
+<context>
+    <name>ProcessThread</name>
+    <message>
+        <location filename="../../src/Thread_Process.cpp" line="116"/>
+        <source>Starting...</source>
+        <translation type="unfinished">開始...</translation>
+    </message>
+    <message>
+        <location filename="../../src/Thread_Process.cpp" line="153"/>
+        <source>Skipped.</source>
+        <translation>省略</translation>
+    </message>
+    <message>
+        <location filename="../../src/Thread_Process.cpp" line="158"/>
+        <source>Not found!</source>
+        <translation type="unfinished">ない！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Thread_Process.cpp" line="233"/>
+        <source>WARNING: Decoded file size exceeds 4 GB, problems might occur!
+</source>
+        <translation type="unfinished">警告 : デコードしたファイルサイズが4GB以上になると問題が起こるかもしれません！
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/Thread_Process.cpp" line="242"/>
+        <source>The format of this file is NOT supported:</source>
+        <translation>このファイル形式は対応していません:</translation>
+    </message>
+    <message>
+        <location filename="../../src/Thread_Process.cpp" line="242"/>
+        <source>Container Format:</source>
+        <translation type="unfinished">コンテナ形式:</translation>
+    </message>
+    <message>
+        <location filename="../../src/Thread_Process.cpp" line="242"/>
+        <source>Audio Format:</source>
+        <translation type="unfinished">音声フォーマット:</translation>
+    </message>
+    <message>
+        <location filename="../../src/Thread_Process.cpp" line="243"/>
+        <source>Unsupported!</source>
+        <translation>未対応！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Thread_Process.cpp" line="349"/>
+        <source>Aborted!</source>
+        <translation>中止！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Thread_Process.cpp" line="349"/>
+        <source>Done.</source>
+        <translation>完了。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Thread_Process.cpp" line="349"/>
+        <source>Failed!</source>
+        <translation>失敗！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Thread_Process.cpp" line="366"/>
+        <source>Encoding</source>
+        <translation>エンコード中</translation>
+    </message>
+    <message>
+        <location filename="../../src/Thread_Process.cpp" line="369"/>
+        <source>Analyzing</source>
+        <translation>分析中</translation>
+    </message>
+    <message>
+        <location filename="../../src/Thread_Process.cpp" line="372"/>
+        <source>Filtering</source>
+        <translation>フィルタ</translation>
+    </message>
+    <message>
+        <location filename="../../src/Thread_Process.cpp" line="375"/>
+        <source>Decoding</source>
+        <translation>デコード中</translation>
+    </message>
+    <message>
+        <location filename="../../src/Thread_Process.cpp" line="399"/>
+        <source>The source audio file could not be found:</source>
+        <translation>入力した音声ファイルが見つかりませんでした:</translation>
+    </message>
+    <message>
+        <location filename="../../src/Thread_Process.cpp" line="407"/>
+        <source>The source audio file could not be opened for reading:</source>
+        <translation>入力した音声ファイルを開くことができませんでした:</translation>
+    </message>
+    <message>
+        <location filename="../../src/Thread_Process.cpp" line="441"/>
+        <source>The target output directory doesn&apos;t exist and could NOT be created:</source>
+        <translation type="unfinished">出力フォルダが存在せず、作成もできませんでした:</translation>
+    </message>
+    <message>
+        <location filename="../../src/Thread_Process.cpp" line="450"/>
+        <source>The target output directory is NOT writable:</source>
+        <translation type="unfinished">出力フォルダには書き込み不可能です:</translation>
+    </message>
+    <message>
+        <location filename="../../src/Thread_Process.cpp" line="503"/>
+        <source>Failed to generate non-existing target file name!</source>
+        <translation type="unfinished">存在しない対象ファイル名の生成に失敗しました(仮訳)！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Thread_Process.cpp" line="511"/>
+        <source>Unknown File Name</source>
+        <translation>不明なファイル名</translation>
+    </message>
+    <message>
+        <location filename="../../src/Thread_Process.cpp" line="513"/>
+        <source>Unknown Title</source>
+        <translation>不明なタイトル</translation>
+    </message>
+    <message>
+        <location filename="../../src/Thread_Process.cpp" line="514"/>
+        <source>Unknown Artist</source>
+        <translation>不明なアーティスト</translation>
+    </message>
+    <message>
+        <location filename="../../src/Thread_Process.cpp" line="515"/>
+        <source>Unknown Album</source>
+        <translation>不明なアルバム</translation>
+    </message>
+    <message>
+        <location filename="../../src/Thread_Process.cpp" line="517"/>
+        <source>Unknown Comment</source>
+        <translation>不明なコメント</translation>
+    </message>
+    <message>
+        <location filename="../../src/Thread_Process.cpp" line="472"/>
+        <source>Target output file already exists, going to skip this file:</source>
+        <translation type="unfinished">対象の出力ファイルは既に存在します。このファイルを飛ばします:</translation>
+    </message>
+    <message>
+        <location filename="../../src/Thread_Process.cpp" line="473"/>
+        <source>If you don&apos;t want existing files to be skipped, please change the overwrite mode!</source>
+        <translation type="unfinished">存在するファイルを飛ばさない場合は、上書きモードに変更してください！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Thread_Process.cpp" line="481"/>
+        <source>Target output file already exists, going to delete existing file:</source>
+        <translation type="unfinished">対象の出力ファイルは既に存在します。存在するファイルを削除します:</translation>
+    </message>
+    <message>
+        <location filename="../../src/Thread_Process.cpp" line="489"/>
+        <source>Failed to delete existing target file, will save to another file name!</source>
+        <translation type="unfinished">既に存在する対象ファイルの削除に失敗しました。違うファイル名で保存します！</translation>
+    </message>
+</context>
+<context>
+    <name>ProcessingDialog</name>
+    <message>
+        <location filename="../../gui/ProcessingDialog.ui" line="14"/>
+        <source>LameXP - Processing</source>
+        <translation>LameXP - 処理中</translation>
+    </message>
+    <message>
+        <location filename="../../gui/ProcessingDialog.ui" line="268"/>
+        <source>Initializing, please wait...</source>
+        <translation>初期化中、お待ちください...</translation>
+    </message>
+    <message>
+        <location filename="../../gui/ProcessingDialog.ui" line="337"/>
+        <source>Shutdown the computer as soon as all files have been converted</source>
+        <translation>すべてのファイルが変換されたらパソコンをシャットダウンする</translation>
+    </message>
+    <message>
+        <location filename="../../gui/ProcessingDialog.ui" line="360"/>
+        <location filename="../../gui/ProcessingDialog.ui" line="416"/>
+        <source>CPU Usage (Overall)</source>
+        <translation>CPU 使用率 (全体)</translation>
+    </message>
+    <message>
+        <location filename="../../gui/ProcessingDialog.ui" line="445"/>
+        <location filename="../../gui/ProcessingDialog.ui" line="495"/>
+        <source>Physical RAM Usage</source>
+        <translation>物理メモリ使用量</translation>
+    </message>
+    <message>
+        <location filename="../../gui/ProcessingDialog.ui" line="524"/>
+        <location filename="../../gui/ProcessingDialog.ui" line="574"/>
+        <source>Free Disk Space (Temp Folder)</source>
+        <translation>ディスクの空き容量 (Temp フォルダ)</translation>
+    </message>
+    <message>
+        <location filename="../../gui/ProcessingDialog.ui" line="679"/>
+        <source>Abort</source>
+        <translation>中止</translation>
+    </message>
+    <message>
+        <location filename="../../gui/ProcessingDialog.ui" line="702"/>
+        <source>Close</source>
+        <translation>閉じる</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Processing.cpp" line="213"/>
+        <source>Show details for selected job</source>
+        <translation>選択した作業の詳細を表示</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Processing.cpp" line="214"/>
+        <source>Browse Output File Location</source>
+        <translation>出力フォルダを参照</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Processing.cpp" line="220"/>
+        <source>Filter Log Items</source>
+        <translation>ログの項目をフィルター</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Processing.cpp" line="222"/>
+        <source>Show Running Only</source>
+        <translation>実行中のみ表示</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Processing.cpp" line="223"/>
+        <source>Show Succeeded Only</source>
+        <translation>成功のみ表示</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Processing.cpp" line="224"/>
+        <source>Show Failed Only</source>
+        <translation>失敗のみ表示</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Processing.cpp" line="225"/>
+        <source>Show Skipped Only</source>
+        <translation>省略のみ表示</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Processing.cpp" line="226"/>
+        <source>Show All Items</source>
+        <translation>すべての項目を表示</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Processing.cpp" line="282"/>
+        <source>Encoding Files</source>
+        <translation>ファイルのエンコード</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Processing.cpp" line="282"/>
+        <source>Your files are being encoded, please be patient...</source>
+        <translation>ファイルをエンコード中です、お待ちください...</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Processing.cpp" line="486"/>
+        <source>Encoding files, please wait...</source>
+        <translation>エンコード中、お待ちください...</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Processing.cpp" line="523"/>
+        <source>Multi-threading enabled: Running %1 instances in parallel!</source>
+        <translation>マルチスレッドが有効です: 並行して %1 個のインスタンスを処理しています！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Processing.cpp" line="655"/>
+        <source>Aborted! Waiting for running jobs to terminate...</source>
+        <translation>中止されました！作業の終了をお待ちください...</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/Dialog_Processing.cpp" line="666"/>
+        <source>Encoding: %n file(s) of %1 completed so far, please wait...</source>
+        <translation type="unfinished">
+            <numerusform>エンコード中: %n ファイルが完了。合計 %1 ファイルあります...</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Processing.cpp" line="688"/>
+        <source>Creating the playlist file, please wait...</source>
+        <translation type="unfinished">プレイリストを作成中、お待ちください...</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/Dialog_Processing.cpp" line="698"/>
+        <source>Process was aborted by the user after %n file(s)!</source>
+        <translation>
+            <numerusform>%n ファイル完了後、処理が中止されました！</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Processing.cpp" line="698"/>
+        <source>Process was aborted prematurely by the user!</source>
+        <translation>ユーザーにより処理が途中で中止されました！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Processing.cpp" line="699"/>
+        <source>LameXP - Aborted</source>
+        <translation>LameXP - 中止</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Processing.cpp" line="699"/>
+        <source>Process was aborted by the user.</source>
+        <translation>ユーザにより処理が中止されました。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Processing.cpp" line="708"/>
+        <source>Process finished after %1.</source>
+        <translation>処理に要した時間 %1。</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/Dialog_Processing.cpp" line="719"/>
+        <source>Error: %1 of %n file(s) failed (%2). Double-click failed items for detailed information!</source>
+        <translation type="unfinished">
+            <numerusform>エラー: %1 ファイルが失敗しています(入力は全%nファイル)(%2)。詳細は項目をダブルクリック！</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/Dialog_Processing.cpp" line="719"/>
+        <source>%n file(s) skipped</source>
+        <translation type="unfinished">
+            <numerusform>%n ファイルが省略されました</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/Dialog_Processing.cpp" line="723"/>
+        <source>Error: %1 of %n file(s) failed. Double-click failed items for detailed information!</source>
+        <translation type="unfinished">
+            <numerusform>エラー: %1 ファイルが失敗しています(入力は全%nファイル)。詳細は項目をダブルクリック！</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Processing.cpp" line="725"/>
+        <source>LameXP - Error</source>
+        <translation type="unfinished">LameXP - エラー</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Processing.cpp" line="725"/>
+        <source>At least one file has failed!</source>
+        <translation type="unfinished">1つ以上のファイルが失敗しました！</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/Dialog_Processing.cpp" line="737"/>
+        <source>All files completed successfully. Skipped %n file(s).</source>
+        <translation type="unfinished">
+            <numerusform>すべてのファイルが成功し、 %n ファイルは省略されました。</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Processing.cpp" line="741"/>
+        <location filename="../../src/Dialog_Processing.cpp" line="743"/>
+        <source>All files completed successfully.</source>
+        <translation type="unfinished">すべてのファイルが成功しました。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Processing.cpp" line="743"/>
+        <source>LameXP - Done</source>
+        <translation type="unfinished">LameXP - 完了</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Processing.cpp" line="930"/>
+        <source>None of the items matches the current filtering rules</source>
+        <translation>フィルターのルールに合致するファイルはありません</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Processing.cpp" line="1043"/>
+        <source>Playlist creation failed</source>
+        <translation type="unfinished">プレイリストの作成に失敗</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Processing.cpp" line="1043"/>
+        <source>The playlist file could not be created:</source>
+        <translation type="unfinished">プレイリストが作成できませんでした:</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Processing.cpp" line="1105"/>
+        <source>Warning: Computer will shutdown in %1 seconds...</source>
+        <translation>警告 : パソコンが %1 秒後にシャットダウンします...</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Processing.cpp" line="1109"/>
+        <location filename="../../src/Dialog_Processing.cpp" line="1110"/>
+        <source>Cancel Shutdown</source>
+        <translation>シャットダウンをキャンセル</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/Dialog_Processing.cpp" line="1205"/>
+        <source>%n hour(s)</source>
+        <translation>
+            <numerusform>%n 時間</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/Dialog_Processing.cpp" line="1206"/>
+        <location filename="../../src/Dialog_Processing.cpp" line="1210"/>
+        <source>%n minute(s)</source>
+        <translation>
+            <numerusform>%n 分</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/Dialog_Processing.cpp" line="1211"/>
+        <location filename="../../src/Dialog_Processing.cpp" line="1215"/>
+        <source>%n second(s)</source>
+        <translation>
+            <numerusform>%n 秒</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/Dialog_Processing.cpp" line="1216"/>
+        <source>%n millisecond(s)</source>
+        <translation>
+            <numerusform>%n ミリ秒</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>ProgressModel</name>
+    <message>
+        <location filename="../../src/Model_Progress.cpp" line="101"/>
+        <source>Job</source>
+        <translation>作業</translation>
+    </message>
+    <message>
+        <location filename="../../src/Model_Progress.cpp" line="104"/>
+        <source>Status</source>
+        <translation>状態</translation>
+    </message>
+</context>
+<context>
+    <name>ShellIntegration</name>
+    <message>
+        <location filename="../../src/ShellIntegration.cpp" line="94"/>
+        <source>Audio File supported by LameXP</source>
+        <translation>LameXP 対応の音声ファイル</translation>
+    </message>
+    <message>
+        <location filename="../../src/ShellIntegration.cpp" line="95"/>
+        <source>Convert this file with LameXP v%1</source>
+        <translation>このファイルを LameXP %1 で変換</translation>
+    </message>
+</context>
+<context>
+    <name>SplashScreen</name>
+    <message>
+        <location filename="../../gui/SplashScreen.ui" line="108"/>
+        <source>LameXP is launching...</source>
+        <translation>LameXP 起動中...</translation>
+    </message>
+</context>
+<context>
+    <name>UpdateDialog</name>
+    <message>
+        <location filename="../../gui/UpdateDialog.ui" line="14"/>
+        <source>LameXP Update Manager</source>
+        <translation>LameXP アップデート管理</translation>
+    </message>
+    <message>
+        <location filename="../../gui/UpdateDialog.ui" line="164"/>
+        <source>Please wait...</source>
+        <translation>お待ちください...</translation>
+    </message>
+    <message>
+        <location filename="../../gui/UpdateDialog.ui" line="349"/>
+        <source>Latest version available:</source>
+        <translation>最新版があります :</translation>
+    </message>
+    <message>
+        <location filename="../../gui/UpdateDialog.ui" line="363"/>
+        <source>Currently installed version:</source>
+        <translation>現在ご使用のバージョン :</translation>
+    </message>
+    <message>
+        <location filename="../../gui/UpdateDialog.ui" line="478"/>
+        <source>Retry</source>
+        <translation>再試行</translation>
+    </message>
+    <message>
+        <location filename="../../gui/UpdateDialog.ui" line="501"/>
+        <source>Show Log</source>
+        <translation>ログを表示</translation>
+    </message>
+    <message>
+        <location filename="../../gui/UpdateDialog.ui" line="573"/>
+        <source>Press Esc button to cancel update check...</source>
+        <translation type="unfinished">更新確認のキャンセル は Esc ボタンです...</translation>
+    </message>
+    <message>
+        <location filename="../../gui/UpdateDialog.ui" line="602"/>
+        <source>Download &amp;&amp; Install</source>
+        <translation type="unfinished">ダウンロードとインストール</translation>
+    </message>
+    <message>
+        <location filename="../../gui/UpdateDialog.ui" line="625"/>
+        <source>Close</source>
+        <translation>閉じる</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Update.cpp" line="162"/>
+        <location filename="../../src/Dialog_Update.cpp" line="367"/>
+        <source>Build</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Update.cpp" line="163"/>
+        <source>Unknown</source>
+        <translation>不明</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Update.cpp" line="252"/>
+        <source>Sorry, but only users in the &quot;Administrators&quot; group can install updates.</source>
+        <translation type="unfinished">すみません。管理者グループのユーザーのみがアップデートをインストールできます。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Update.cpp" line="253"/>
+        <source>Please start application from an administrator account and try again!</source>
+        <translation type="unfinished">管理者アカウントからソフトウェアを実行しもう一度試してください！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Update.cpp" line="290"/>
+        <source>Testing your internet connection, please wait...</source>
+        <translation>インターネット接続を確認中。お待ちください...</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Update.cpp" line="311"/>
+        <source>It appears that the computer currently is offline!</source>
+        <translation>パソコンがオフラインのようです！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Update.cpp" line="312"/>
+        <location filename="../../src/Dialog_Update.cpp" line="317"/>
+        <source>Please make sure your computer is connected to the internet and try again.</source>
+        <translation>パソコンがインターネットに接続されているか確認し、もう一度お試しください。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Update.cpp" line="316"/>
+        <source>Network connectivity test has failed!</source>
+        <translation type="unfinished">ネットワーク接続テストが失敗しました！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Update.cpp" line="293"/>
+        <source>Checking for new updates online, please wait...</source>
+        <translation>アップデートをオンラインで確認中...</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Update.cpp" line="321"/>
+        <source>Failed to fetch update information from server!</source>
+        <translation type="unfinished">サーバーからの更新情報の取得に失敗しました！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Update.cpp" line="322"/>
+        <source>Sorry, the update server might be busy at this time. Plase try again later.</source>
+        <translation type="unfinished">すみません。ただいま更新サーバーに接続できないようです。後でお試しください。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Update.cpp" line="366"/>
+        <source>More information available at:</source>
+        <translation type="unfinished">詳しい情報はこちらにあります :</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Update.cpp" line="296"/>
+        <source>A new version of LameXP is available!</source>
+        <translation type="unfinished">LameXP の新しいバージョンがあります！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Update.cpp" line="207"/>
+        <source>Stopping update check, please wait...</source>
+        <translation type="unfinished">更新チェックを停止中...</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Update.cpp" line="254"/>
+        <source>Discard</source>
+        <translation type="unfinished">閉じる</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Update.cpp" line="254"/>
+        <source>Ignore</source>
+        <translation>無視</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Update.cpp" line="287"/>
+        <source>Initializing, please wait...</source>
+        <translation type="unfinished">初期化中...</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Update.cpp" line="297"/>
+        <source>We highly recommend all users to install this update as soon as possible.</source>
+        <translation type="unfinished">このアップデートを速やかにインストールすることを強く推奨します。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Update.cpp" line="301"/>
+        <source>No new updates available at this time.</source>
+        <translation>アップデートはありません。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Update.cpp" line="302"/>
+        <source>Your version of LameXP is still up-to-date. Please check for updates regularly!</source>
+        <translation>現在の LameXP はまだ最新版です。定期的にアップデートを確認してください！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Update.cpp" line="306"/>
+        <source>Your version appears to be newer than the latest release.</source>
+        <translation type="unfinished">最新版よりも新しいものを使用しているようです。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Update.cpp" line="307"/>
+        <source>This usually indicates your are currently using a pre-release version of LameXP.</source>
+        <translation type="unfinished">正式公開前のバージョンの LameXP をお使いかもしれません。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Update.cpp" line="326"/>
+        <source>Update check has been cancelled!</source>
+        <translation type="unfinished">アップデートの確認はキャンセルされました！</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Update.cpp" line="327"/>
+        <source>The update check has been cancelled by the user. Please try again later.</source>
+        <translation type="unfinished">更新確認はあなたによってキャンセルされました。後ほど再びお試しください。</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Update.cpp" line="395"/>
+        <source>Update is being downloaded, please be patient...</source>
+        <translation type="unfinished">アップデートをダウンロードしています。少々お待ちください...</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Update.cpp" line="443"/>
+        <source>Update ready to install. Applicaion will quit...</source>
+        <translation type="unfinished">アップデートをインストールできます。いったん終了します...</translation>
+    </message>
+    <message>
+        <location filename="../../src/Dialog_Update.cpp" line="451"/>
+        <source>Update failed. Please try again or download manually!</source>
+        <translation type="unfinished">アップデートに失敗しました。もう一度試すか手動で更新してください！</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
In [Forest of Windows](https://forest.watch.impress.co.jp/docs/review/732243.html), Big Japanese software introduce site, is also mentioned LameXP. But it is english software. So I translate it.

I read "Translate.html", Is the upload path correct here?:
"etc\Translation"

"Blank.ts" was in here. I translated this.